### PR TITLE
Fix parsing name_tree when names partially match builtins

### DIFF
--- a/doc/agile/product_backlog.org
+++ b/doc/agile/product_backlog.org
@@ -2742,13 +2742,6 @@ from the spirit documentation:
 [[http://www.boost.org/doc/libs/1_52_0/libs/spirit/repository/doc/html/spirit_repository/qi_components/directives/distinct.html][- Qi Distinct Parser Directive]]
 - [[http://www.boost.org/doc/libs/1_52_0/libs/spirit/repository/test/qi/distinct.cpp][distinct.cpp]]
 
-However, we still haven't solved the following cases:
-
-: BOOST_CHECK(test_builtin("longer"));
-: BOOST_CHECK(test_builtin("unsigneder"));
-
-As these are not so common they have been left for later.
-
 Seems like the thing to do here is to create a keyword parser and nest
 it with the existing parsers:
 

--- a/projects/yarn/tests/name_tree_parser_tests.cpp
+++ b/projects/yarn/tests/name_tree_parser_tests.cpp
@@ -327,8 +327,8 @@ BOOST_AUTO_TEST_CASE(names_that_partially_match_builtins_produce_expected_name_t
     BOOST_CHECK(test_builtin("floa"));
     BOOST_CHECK(test_builtin("doubler"));
     BOOST_CHECK(test_builtin("doubl"));
-    // BOOST_CHECK(test_builtin("unsigneder"));
-    // BOOST_CHECK(test_builtin("longer"));
+    BOOST_CHECK(test_builtin("unsigneder"));
+    BOOST_CHECK(test_builtin("longer"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This strictly just makes the tests pass. It does not address other lingering issues in the parser yet, nor does it add testcases for more complicated uses (what about parsing `long␣␣long` or `unsigned␣␣␣char`?).

I concur with the backlog that a `qi::symbol` Trie lookup is more flexible (though it will not directly allow handling of multi-keyword builtins). A little more design drafting seems required before embarking on any implementation/ProofOfConcept.